### PR TITLE
feat: add item system with shop and inventory

### DIFF
--- a/Assets/Scripts/Item.cs
+++ b/Assets/Scripts/Item.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+[System.Serializable]
+public class Item
+{
+    public string itemName;
+    public int cost;
+    public StatModifier[] modifiers;
+}
+
+[System.Serializable]
+public struct StatModifier
+{
+    public StatType stat;
+    public float amount;
+}
+
+public enum StatType
+{
+    Health,
+    Damage,
+    Speed
+}

--- a/Assets/Scripts/Item.cs.meta
+++ b/Assets/Scripts/Item.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ae29fcfae0e462b8523cff903dfda28
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MainCharacterController.cs
+++ b/Assets/Scripts/MainCharacterController.cs
@@ -34,6 +34,8 @@ public class MainCharacterController : MonoBehaviour
  
     [SerializeField]
     private int helthPoint;
+    [SerializeField]
+    private float damage = 1f;
 
     private void Start()
     {
@@ -181,12 +183,34 @@ public class MainCharacterController : MonoBehaviour
         isDead = true;
         transform.position = playerSpawner.position;
         yield return new WaitForSecondsRealtime(0.1f);
-     
+
         transform.position = playerSpawner.position;
         helthPoint = 3;
         onHelthChange?.Invoke(helthPoint);
-        
+
         isDead = false;
+    }
+
+    public void AddSpeed(float amount)
+    {
+        speed += amount;
+    }
+
+    public void AddDamage(float amount)
+    {
+        damage += amount;
+    }
+
+    public void AddHealth(int amount)
+    {
+        helthPoint += amount;
+        helthPoint = Mathf.Clamp(helthPoint, 0, 3);
+        onHelthChange?.Invoke(helthPoint);
+    }
+
+    public float GetDamage()
+    {
+        return damage;
     }
 
 }

--- a/Assets/Scripts/PlayerInventory.cs
+++ b/Assets/Scripts/PlayerInventory.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerInventory : MonoBehaviour
+{
+    public int gold;
+    public List<Item> items = new List<Item>();
+    public MainCharacterController controller;
+
+    private void Awake()
+    {
+        if (controller == null) controller = GetComponent<MainCharacterController>();
+    }
+
+    public bool Purchase(Item item)
+    {
+        if (gold < item.cost) return false;
+        gold -= item.cost;
+        items.Add(item);
+        ApplyItem(item);
+        return true;
+    }
+
+    private void ApplyItem(Item item)
+    {
+        foreach (var mod in item.modifiers)
+        {
+            switch (mod.stat)
+            {
+                case StatType.Health:
+                    controller.AddHealth((int)mod.amount);
+                    break;
+                case StatType.Damage:
+                    controller.AddDamage(mod.amount);
+                    break;
+                case StatType.Speed:
+                    controller.AddSpeed(mod.amount);
+                    break;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/PlayerInventory.cs.meta
+++ b/Assets/Scripts/PlayerInventory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 64cc0d39eb534ebcb0051c16004e0512
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Shooting.cs
+++ b/Assets/Scripts/Shooting.cs
@@ -2,39 +2,30 @@ using UnityEngine;
 
 public class Shooting : MonoBehaviour
 {
+    private MainCharacterController controller;
+
+    private void Awake()
+    {
+        controller = GetComponentInParent<MainCharacterController>();
+    }
 
     public void Update()
     {
         if (Input.GetMouseButtonDown(0))
         {
-            // 2 ways of shooting (1 to mouse posion \ 2 to formard by rotation)
-
-            // Vector3 direction = (Utils.mouseWorldPosition - bulletSpawnPosition.position).normalized;
-            //  direction.y = 0;
-
             Vector3 direction = (transform.rotation * Vector3.forward).normalized;
             direction.y = 0;
-
             GunShoot(direction);
         }
     }
 
-
-   // public GameObject bulletPrefab;
     public Transform bulletSpawnPosition;
 
     protected virtual void GunShoot(Vector3 bulletDirection)
     {
-        GameObject bullet = PoolManager.GetObject("bullet",bulletSpawnPosition.position, Quaternion.identity);
-
-     
-
-        bullet.GetComponent<Bullet>().Setup(bulletDirection, 25, 1f);
+        GameObject bullet = PoolManager.GetObject("bullet", bulletSpawnPosition.position, Quaternion.identity);
+        float damage = controller != null ? controller.GetDamage() : 1f;
+        bullet.GetComponent<Bullet>().Setup(bulletDirection, 25, damage);
         bullet.GetComponent<PoolObject>().ReturnToPool(3);
-
     }
-
-
-
-
 }

--- a/Assets/Scripts/Shop.cs
+++ b/Assets/Scripts/Shop.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+public class Shop : MonoBehaviour
+{
+    public Item[] stock;
+    public PlayerInventory inventory;
+
+    public void Buy(int index)
+    {
+        if (index < 0 || index >= stock.Length) return;
+        if (inventory != null)
+        {
+            inventory.Purchase(stock[index]);
+        }
+    }
+}

--- a/Assets/Scripts/Shop.cs.meta
+++ b/Assets/Scripts/Shop.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c1478a5c8304683b14d5f60ebd13b11
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add serializable item definition with stat modifiers
- create player inventory and shop scripts to purchase and apply items
- allow items to modify player speed, health, and damage
- connect shooting to player damage

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689280e6e4c48327aff1a96a0be0fcd5